### PR TITLE
MxDSFile::Open improvements

### DIFF
--- a/LEGO1/mxdsfile.cpp
+++ b/LEGO1/mxdsfile.cpp
@@ -27,26 +27,28 @@ long MxDSFile::Open(unsigned long uStyle)
 {
   // No idea what's stopping this one matching, but I'm pretty
   // confident it has the correct behavior.
+  long longResult = 1;
   memset(&m_io, 0, sizeof(MXIOINFO));
+
   if (m_io.Open(m_filename.GetData(), uStyle) != 0) {
     return -1;
   }
 
-  m_io.SetBuffer(NULL, 0);
+  m_io.SetBuffer(NULL, 0, 0);
   m_position = 0;
 
-  long longResult = 1;
-  if (m_skipReadingChunks == 0)
-  {
+  if (m_skipReadingChunks == 0) {
     longResult = ReadChunks();
   }
-  if (longResult != 0)
-  {
+
+  if (longResult != 0) {
     Close(); // vtable + 0x18
-    return longResult;
   }
-  Seek(0, 0); // vtable + 0x24
-  return 0;
+  else {
+    Seek(0, 0); // vtable + 0x24
+  }
+
+  return longResult;
 }
 
 // OFFSET: LEGO1 0x100cc780

--- a/LEGO1/mxioinfo.cpp
+++ b/LEGO1/mxioinfo.cpp
@@ -37,7 +37,7 @@ LONG MXIOINFO::Seek(LONG lOffset, int iOrigin)
 }
 
 // OFFSET: LEGO1 0x100ccbc0
-void MXIOINFO::SetBuffer(LPSTR pchBuffer, LONG cchBuffer)
+void MXIOINFO::SetBuffer(LPSTR pchBuffer, LONG cchBuffer, LONG unk)
 {
   
 }

--- a/LEGO1/mxioinfo.h
+++ b/LEGO1/mxioinfo.h
@@ -13,7 +13,7 @@ public:
   void Close(long arg);
   LONG Seek(LONG lOffset, int iOrigin);
   unsigned long Read(HPSTR pch, LONG cch);
-  void SetBuffer(LPSTR pchBuffer, LONG cchBuffer);
+  void SetBuffer(LPSTR pchBuffer, LONG cchBuffer, LONG unk);
   unsigned short Descend(LPMMCKINFO pmmcki, const MMCKINFO *pmmckiParent, UINT fuDescend);
 
   MMIOINFO m_info;


### PR DESCRIPTION
A few minor improvements leading to better accuracy. It's not 100% there yet, but the emitted assembly seems correct now apart from the fact that some instructions are swapped / registers assigned a bit differently. Not sure if this can be further influecend though.

Key changes that were made:

* `longResult` on top
* Function needs to return `longResult`
* `SetBuffer` appears to have one extra, but unused parameter

CC https://github.com/isledecomp/isle/pull/51